### PR TITLE
Added execute permission for wrapper file

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -36,6 +36,7 @@ export GRADLE_USER_HOME=$CACHE_DIR
 
 if [ -f $BUILD_DIR/gradlew ] ; then
   BUILDCMD="./gradlew"
+  chmod +x ${BUILD_DIR}/gradlew
 else
   if [ ! -d $CACHE_DIR/$GRADLE_DIST ] ; then
     cd $CACHE_DIR


### PR DESCRIPTION
Sending a gradle wrapper failed with a permission error.

Added permission.
