### PR TITLE
use init script when building with gradle wrapper

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -40,7 +40,7 @@ fi
 export GRADLE_USER_HOME=$CACHE_DIR
 
 if [ -f $BUILD_DIR/gradlew ] ; then
-  BUILDCMD="./gradlew"
+  BUILDCMD="./gradlew -I $OPT_DIR/init.gradle"
 else
   if [ ! -d $CACHE_DIR/$GRADLE_DIST ] ; then
     cd $CACHE_DIR


### PR DESCRIPTION
Otherwise, wrapper builds don't use the S3 mirror repository
