### PR TITLE
detect: support projects with non-default build file names

### DIFF
--- a/bin/detect
+++ b/bin/detect
@@ -2,7 +2,9 @@
 # bin/use <build-dir>
 
 if [ -f $1/build.gradle ]; then
-   echo "Gradle" && exit 0
+  echo "Gradle" && exit 0
+elif [ -f $1/settings.gradle ]; then
+  echo "Gradle" && exit 0
 else
   echo "no" && exit 1
 fi

--- a/test/detect_test.sh
+++ b/test/detect_test.sh
@@ -2,7 +2,16 @@
 
 . ${BUILDPACK_TEST_RUNNER_HOME}/lib/test_utils.sh
 
-testDetect()
+testDetechSettingsGradle()
+{
+  touch ${BUILD_DIR}/settings.gradle
+
+  detect
+
+  assertAppDetected "Gradle"
+}
+
+testDetectBuildGradle()
 {
   touch ${BUILD_DIR}/build.gradle
   
@@ -11,7 +20,7 @@ testDetect()
   assertAppDetected "Gradle"
 }
 
-testNoDetectMissingBuildGradle()
+testNoDetectMissingBuildGradleAndSettingsGradle()
 {
   touch ${BUILD_DIR}/build.xml
 


### PR DESCRIPTION
With Gradle, it's possible to have a valid project where no file named `build.gradle` is used.
For these projects, you set the `buildFileName` on the `ProjectDescriptor` in your `settings.gradle`.
The Ratpack project is currently an example of this type of project.
Thus, I've changed the detect logic to consider an application as a Gradle application when either
`build.gradle` or `settings.gradle` is found.

http://www.gradle.org/docs/current/dsl/org.gradle.api.initialization.Settings.html
http://www.gradle.org/docs/current/javadoc/org/gradle/api/initialization/ProjectDescriptor.html
https://github.com/ratpack/ratpack
