### PR TITLE
typo in usage documentation

### DIFF
--- a/bin/detect
+++ b/bin/detect
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# bin/use <build-dir>
+# bin/detect <build-dir>
 
 if [ -f $1/gradlew ]; then
   echo "Gradle" && exit 0


### PR DESCRIPTION
`bin/detect` is documented as `bin/use` in the header comments