### PR TITLE
Added support for Kotlin script DSL

### DIFF
--- a/bin/detect
+++ b/bin/detect
@@ -4,13 +4,12 @@
 if [ -f $1/gradlew ]; then
   echo "Gradle" && exit 0
 
-# Detect these Gradle specific files, so we can fail with a message 
-# asking the user to enable the Gradle Wrapper for their project.  
+# Detect these Gradle specific files, so we can fail with a message
+# asking the user to enable the Gradle Wrapper for their project.
 elif [ -f $1/build.gradle ]; then
   echo "Gradle" && exit 0
 elif [ -f $1/settings.gradle ]; then
   echo "Gradle" && exit 0
-
 else
   echo "no" && exit 1
 fi

--- a/hatchet.json
+++ b/hatchet.json
@@ -11,5 +11,9 @@
   ],
   "grails": [
     "kissaten/grails3-example"
+  ],
+  "kotlin": [
+    "kissaten/gradle-kotlin-dsl-sample",
+    "kissaten/spring-boot-gradle-kotlin-dsl"
   ]
 }

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -2,35 +2,44 @@
 
 export BUILDPACK_STDLIB_URL="https://lang-common.s3.amazonaws.com/buildpack-stdlib/v7/stdlib.sh"
 
-has_stage_task() {
+gradle_build_file() {
   local buildDir=${1}
-   test -f ${buildDir}/build.gradle &&
-     test -n "$(grep "^ *task *stage" ${buildDir}/build.gradle)"
+  if [ -f ${buildDir}/build.gradle.kts ]; then
+    echo "${buildDir}/build.gradle.kts"
+  else
+    echo "${buildDir}/build.gradle"
+  fi
+}
+
+has_stage_task() {
+  local gradleFile="$(gradle_build_file ${1})"
+   test -f ${gradleFile} &&
+     test -n "$(grep "^ *task *stage" ${gradleFile})"
 }
 
 is_spring_boot() {
-  local buildDir=${1}
-   test -f ${buildDir}/build.gradle &&
-     test -n "$(grep "^[^/].*org.springframework.boot:spring-boot" ${buildDir}/build.gradle)" &&
-     test -z "$(grep "org.grails:grails-" ${buildDir}/build.gradle)"
+  local gradleFile="$(gradle_build_file ${1})"
+   test -f ${gradleFile} &&
+     test -n "$(grep "^[^/].*org.springframework.boot:spring-boot" ${gradleFile})" &&
+     test -z "$(grep "org.grails:grails-" ${gradleFile})"
 }
 
 is_ratpack() {
-  local buildDir=${1}
-  test -f ${buildDir}/build.gradle &&
-    test -n "$(grep "^[^/].*io.ratpack.ratpack" ${buildDir}/build.gradle)"
+  local gradleFile="$(gradle_build_file ${1})"
+  test -f ${gradleFile} &&
+    test -n "$(grep "^[^/].*io.ratpack.ratpack" ${gradleFile})"
 }
 
 is_grails() {
-  local buildDir=${1}
-   test -f ${buildDir}/build.gradle &&
-     test -n "$(grep "^[^/].*org.grails:grails-" ${buildDir}/build.gradle)"
+  local gradleFile="$(gradle_build_file ${1})"
+   test -f ${gradleFile} &&
+     test -n "$(grep "^[^/].*org.grails:grails-" ${gradleFile})"
 }
 
 is_webapp_runner() {
-  local buildDir=${1}
-  test -f ${buildDir}/build.gradle &&
-    test -n "$(grep "^[^/].*io.ratpack.ratpack" ${buildDir}/build.gradle)"
+  local gradleFile="$(gradle_build_file ${1})"
+  test -f ${gradleFile} &&
+    test -n "$(grep "^[^/].*io.ratpack.ratpack" ${gradleFile})"
 }
 
 create_build_log_file() {

--- a/spec/kotlin_spec.rb
+++ b/spec/kotlin_spec.rb
@@ -1,0 +1,42 @@
+require_relative 'spec_helper'
+
+describe "Gradle" do
+
+  before(:each) do
+    init_app(app)
+  end
+
+  context "on JDK 8" do
+    let(:app) { Hatchet::Runner.new("gradle-kotlin-dsl-sample") }
+    let(:jdk_version) { "1.8" }
+
+    it "deploys successfully" do
+      app.deploy do |app|
+        expect(app.output).not_to include("Ratpack detected")
+        expect(app.output).not_to include("Spring Boot detected")
+        expect(app.output).not_to include("Spring Boot and Webapp Runner detected")
+        expect(app.output).to include("Building Gradle app")
+        expect(app.output).to include("executing ./gradlew stage")
+        expect(app.output).to include("BUILD SUCCESSFUL")
+        expect(successful_body(app)).to eq("Hello from Kotlin")
+      end
+    end
+  end
+
+  context "with Spring Boot" do
+    let(:app) { Hatchet::Runner.new("spring-boot-gradle-kotlin-dsl") }
+    let(:jdk_version) { "1.8" }
+
+    it "deploys successfully" do
+      app.deploy do |app|
+        expect(app.output).not_to include("Ratpack detected")
+        expect(app.output).not_to include("Spring Boot and Webapp Runner detected")
+        expect(app.output).to include("Spring Boot detected")
+        expect(app.output).to include("Building Gradle app")
+        expect(app.output).to include("executing ./gradlew build -x test")
+        expect(app.output).to include("BUILD SUCCESSFUL")
+        expect(successful_body(app)).to eq("Hello from Spring Boot")
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR adds detection of `build.gradle.kts` files writen using [Kotlin Script DSL for Gradle](https://blog.gradle.org/kotlin-meets-gradle). Also adds Hatchet tests for sample apps. 