### PR TITLE
Add stderr message when bin/detect fails

### DIFF
--- a/bin/detect
+++ b/bin/detect
@@ -11,5 +11,6 @@ elif [ -f $1/build.gradle ]; then
 elif [ -f $1/settings.gradle ]; then
   echo "Gradle" && exit 0
 else
-  echo "no" && exit 1
+  (>&2 echo "Could not find a 'gradlew' script or a 'build.gradle' file! Please check that they exist and are commited to Git.")
+  exit 1
 fi

--- a/test/detect_test.sh
+++ b/test/detect_test.sh
@@ -27,12 +27,12 @@ testNoDetectAntProject()
 {
   touch ${BUILD_DIR}/build.xml
   detect
-  assertNoAppDetected
+  assertEquals "1" "${RETURN}"
 }
 
 testNoDetectMavenProject()
 {
   touch ${BUILD_DIR}/pom.xml
   detect
-  assertNoAppDetected
+  assertEquals "1" "${RETURN}"
 }


### PR DESCRIPTION
This will look like:

```
remote: Building source:
remote:
remote: -----> App not compatible with buildpack: heroku/gradle
remote:        Could not find a 'gradlew' script or a 'build.gradle' file! Please check that they exist and are commited to Git.
remote:
remote:        More info: https://devcenter.heroku.com/articles/buildpacks#detection-failure
remote:
remote:  !     Push failed
remote: Verifying deploy...
remote:
remote: !       Push rejected to jkutner-test.
remote:
```