### PR TITLE
Remove .gradle/nodejs from cache to prevent broken symlinks

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -86,4 +86,7 @@ if [ "${PIPESTATUS[*]}" != "0 0" ]; then
   handle_gradle_errors $buildLogFile
 fi
 
+# https://github.com/heroku/heroku-buildpack-gradle/issues/49
+rm -rf "$CACHE_DIR/.gradle/nodejs"
+
 mtime "build.time" "${start}"


### PR DESCRIPTION
Fixes #49