### PR TITLE
Prepare for release v32

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## main
 
+## v32
+
+* Update tests
+
+## v31
+
 * Search for spring-boot-detect-plugin when detecting Spring Boot apps
 
 ## v30


### PR DESCRIPTION
In addition, add a proper heading for the previous `v31` release.