### PR TITLE
Run all "check" tasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## main
 
+* Run all tests defined by "check" task (Set `GRADLE_TESTPACK_LEGACY_TASK` to a non-empty value to restore old behavior)
+
 ## v33
 
 * Enable heroku-20 testing

--- a/bin/compile
+++ b/bin/compile
@@ -22,6 +22,11 @@ source <(curl --retry 3 -fsSL $BUILDPACK_STDLIB_URL)
 
 export_env $ENV_DIR "." "JAVA_OPTS|JAVA_TOOL_OPTIONS"
 
+GRADLE_CHECK_TASK=check
+if [ -n "${GRADLE_TESTPACK_LEGACY_TASK:-}" ]; then
+  GRADLE_CHECK_TASK=test
+fi
+
 if has_stage_task $BUILD_DIR; then
   mcount "task.stage"
   DEFAULT_GRADLE_TASK="stage"
@@ -33,11 +38,11 @@ elif is_spring_boot $BUILD_DIR; then
     echo "-----> Spring Boot detected"
     mcount "task.spring"
   fi
-  DEFAULT_GRADLE_TASK="build -x test"
+  DEFAULT_GRADLE_TASK="build -x ${GRADLE_CHECK_TASK}"
 elif is_ratpack $BUILD_DIR; then
   echo "-----> Ratpack detected"
   mcount "task.ratpack"
-  DEFAULT_GRADLE_TASK="installDist -x test"
+  DEFAULT_GRADLE_TASK="installDist -x ${GRADLE_CHECK_TASK}"
 else
   DEFAULT_GRADLE_TASK="stage"
 fi

--- a/bin/test
+++ b/bin/test
@@ -4,4 +4,9 @@
 # fail fast
 set -e
 
-cd ${1} && ./gradlew --gradle-user-home "$1/.gradle" --no-daemon test
+GRADLE_CHECK_TASK=check
+if [ -n "${GRADLE_TESTPACK_LEGACY_TASK:-}" ]; then
+  GRADLE_CHECK_TASK=test
+fi
+
+cd ${1} && ./gradlew --gradle-user-home "$1/.gradle" --no-daemon "${GRADLE_CHECK_TASK}"

--- a/test/spec/gradle_spec.rb
+++ b/test/spec/gradle_spec.rb
@@ -15,7 +15,7 @@ describe "Gradle" do
           expect(app.output).not_to include("Spring Boot and Webapp Runner detected")
           expect(app.output).to include("Building Gradle app")
           expect(app.output).not_to include("executing ./gradlew stage")
-          expect(app.output).to include("executing ./gradlew build -x test")
+          expect(app.output).to include("executing ./gradlew build -x check")
           expect(app.output).to include("BUILD SUCCESSFUL")
         end
       end

--- a/test/spec/kotlin_spec.rb
+++ b/test/spec/kotlin_spec.rb
@@ -33,7 +33,7 @@ describe "Gradle" do
           expect(app.output).not_to include("Spring Boot and Webapp Runner detected")
           expect(app.output).to include("Spring Boot detected")
           expect(app.output).to include("Building Gradle app")
-          expect(app.output).to include("executing ./gradlew build -x test")
+          expect(app.output).to include("executing ./gradlew build -x check")
           expect(app.output).to include("BUILD SUCCESSFUL")
           expect(http_get(app)).to eq("Hello from Spring Boot")
         end

--- a/test/spec/ratpack_spec.rb
+++ b/test/spec/ratpack_spec.rb
@@ -12,7 +12,7 @@ describe "Ratpack" do
         app.deploy do
           expect(app.output).to include("Ratpack detected")
           expect(app.output).to include("Building Gradle app")
-          expect(app.output).to include("executing ./gradlew installDist -x test")
+          expect(app.output).to include("executing ./gradlew installDist -x check")
           expect(app.output).not_to include(":test")
           expect(app.output).to include("BUILD SUCCESSFUL")
           expect(http_get(app)).to include("Groovy Web Console")

--- a/test/spec/spring_spec.rb
+++ b/test/spec/spring_spec.rb
@@ -12,7 +12,7 @@ describe "Spring" do
         app.deploy do
           expect(app.output).to include("Spring Boot detected")
           expect(app.output).to include("Building Gradle app")
-          expect(app.output).to include("executing ./gradlew build -x test")
+          expect(app.output).to include("executing ./gradlew build -x check")
           expect(app.output).to include("Downloading https://services.gradle.org/distributions/gradle-")
           expect(app.output).not_to include(":test")
           expect(app.output).to include("BUILD SUCCESSFUL")
@@ -25,7 +25,7 @@ describe "Spring" do
 
           expect(app.output).to include("Spring Boot detected")
           expect(app.output).to include("Building Gradle app")
-          expect(app.output).to include("executing ./gradlew build -x test")
+          expect(app.output).to include("executing ./gradlew build -x check")
           expect(app.output).not_to include("Downloading https://services.gradle.org/distributions/gradle-")
           expect(app.output).not_to include(":test")
           expect(app.output).to include("BUILD SUCCESSFUL")


### PR DESCRIPTION
Run all "check" tasks

Depend on the `check` Lifecycle Task to execute all default and
user-defined verification tasks. The new default behavior is to run
`check`. Users can set `GRADLE_TESTPACK_LEGACY_TASK` to any non-empty
value to restore the old behavior of running only the `test` task.

The [Gradle Java Plugin][1] defines a task hierarchy, with the `build`
task at the top which executes all other tasks. Test tasks are split
into the top level task `check` which depends on `test`.

> **check**
>
> Depends on: `test`
>
> Aggregate task that performs verification tasks, such as running the
> tests. Some plugins add their own verification tasks to check. You
> should also attach any custom Test tasks to this lifecycle task if you
> want them to execute for a full build. This task is added by the Base
> Plugin.

Often it is useful to split unit tests and integration tests into
distinct source sets and tasks. The [canonical example][2] from the
Gradle docs links this new test task to the `check` top level task.

[1]: https://docs.gradle.org/current/userguide/java_plugin.html
[2]: https://docs.gradle.org/current/userguide/java_testing.html#sec:configuring_java_integration_tests