### PR TITLE
Fix appending additional system properties to GRADLE_OPTS environment variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## main
 
+* Fix a bug causing Gradle daemon to be unintentionally used when executing builds 
+
 ## v35
 
 * Update tests

--- a/bin/compile
+++ b/bin/compile
@@ -53,7 +53,7 @@ fi
 
 install_jdk "${BUILD_DIR}" "${CACHE_DIR}"
 
-export GRADLE_OPTS=${GRADLE_OPTS-"-Dorg.gradle.daemon=false -Dorg.gradle.internal.launcher.welcomeMessageEnabled=false"}
+export GRADLE_OPTS="${GRADLE_OPTS}${GRADLE_OPTS:+ }-Dorg.gradle.daemon=false -Dorg.gradle.internal.launcher.welcomeMessageEnabled=false"
 
 mkdir -p "$CACHE_DIR/.gradle"
 export GRADLE_USER_HOME=${GRADLE_USER_HOME:-$CACHE_DIR/.gradle}


### PR DESCRIPTION
As far as I can tell the
```
export GRADLE_OPTS=${GRADLE_OPTS-"-Dorg.gradle.daemon=false -Dorg.gradle.internal.launcher.welcomeMessageEnabled=false"}
```
command has no effect and after executing it the the value of `GRADLE_OPTS` will be whatever it was before. 

The drawback of `org.gradle.daemon` system property not being set to `false` is that deployments are needlessly starting daemons on agents where it's likely that multiple Gradle versions will be used which leads to multiple daemons hanging around. This is confirmed by messages in deployment logs like this one:
```
-----> executing ./gradlew stage
       Starting a Gradle Daemon, 17 incompatible Daemons could not be reused, use --status for details
```
This example is from deployment `995913db-84b0-4be0-a4b1-1fb9cd0cda40` of `gebish` app.

But more importantly for me, it seems that when a daemon is reused then the deployment will fail:
```
-----> Building on the Heroku-18 stack
-----> Using buildpack: https://github.com/heroku/heroku-buildpack-gradle.git
-----> Gradle app detected
-----> Installing JDK 1.8... done
-----> Building Gradle app...
-----> executing ./gradlew stage
       
       FAILURE: Build failed with an exception.
       
       * What went wrong:
       Supplied javaHome must be a valid directory. You supplied: /tmp/build_0cf3c405/.jdk
       
       * Try:
       Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output. Run with --scan to get full insights.
       
       * Get more help at https://help.gradle.org
```
I've seen this in the following deployments of `gebish` app:
- `caaf3ae2-efb6-4862-8ee3-102385ddca55`
- `58e1324f-d629-40ba-b7c2-4d7db45e07b4`
- `17ca9180-5e26-42e0-8c6c-8360559325ae`
- `c34ea19d-5c2e-4e6e-970b-5718f3e2a2b3`

I suspect it has something to do with the fact that `/tmp/build_0cf3c405/.jdk` is a directory that was created by a previous deployment which also started the daemon being reused and one that no longer exists.

These failures are basically what made me fix this in a fork which I'm currently using for my deployments and then submit this PR.