### PR TITLE
Add heroku-22 support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,13 +10,16 @@ executors:
   heroku-20:
     docker:
       - image: heroku/heroku:20
+  heroku-22:
+    docker:
+      - image: heroku/heroku:22
 
 jobs:
   hatchet:
     parameters:
       heroku-stack:
         type: enum
-        enum: ["heroku-18", "heroku-20"]
+        enum: ["heroku-18", "heroku-20", "heroku-22"]
     docker:
       - image: circleci/ruby:2.7
     environment:
@@ -78,4 +81,4 @@ workflows:
       - hatchet:
           matrix:
             parameters:
-              heroku-stack: ["heroku-18", "heroku-20"]
+              heroku-stack: ["heroku-18", "heroku-20", "heroku-22"]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## main
 
+## v37
+
+* Add heroku-22 support
+
+## v36
+
 * Fix a bug causing Gradle daemon to be unintentionally used when executing builds 
 * Remove heroku-16 support
 


### PR DESCRIPTION
Changelog updated for immediate release and missing `v36` release.

Closes GUS-W-10343931
