### PR TITLE
Switch to the recommended regional S3 domain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## main
 
 * Vendor buildpack-stdlib rather than downloading it at build time
+* Switch to the recommended regional S3 domain instead of the global one
 
 ## v37
 

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -92,7 +92,7 @@ install_jdk() {
   local cache_dir=${2:?}
 
   let start=$(nowms)
-  JVM_COMMON_BUILDPACK=${JVM_COMMON_BUILDPACK:-https://buildpack-registry.s3.amazonaws.com/buildpacks/heroku/jvm.tgz}
+  JVM_COMMON_BUILDPACK=${JVM_COMMON_BUILDPACK:-https://buildpack-registry.s3.us-east-1.amazonaws.com/buildpacks/heroku/jvm.tgz}
   mkdir -p /tmp/jvm-common
   curl --retry 3 --silent --location $JVM_COMMON_BUILDPACK | tar xzm -C /tmp/jvm-common --strip-components=1
   source /tmp/jvm-common/bin/util


### PR DESCRIPTION
Whilst the global S3 endpoint (`s3.amazonaws.com`) still works, AWS now recommends using the appropriate regional endpoint to access the bucket:
https://docs.aws.amazon.com/AmazonS3/latest/userguide/VirtualHosting.html#s3-legacy-endpoints

Our buildpack buckets are in `us-east-1`, whose regional domain is `*.s3.us-east-1.amazonaws.com`:
https://docs.aws.amazon.com/general/latest/gr/s3.html#s3_region

GUS-W-11283397.