### PR TITLE
Only use curl's `--retry-connrefused` when supported

### DIFF
--- a/.github/workflows/check_changelog.yml
+++ b/.github/workflows/check_changelog.yml
@@ -2,17 +2,20 @@ name: Check Changelog
 
 on:
   pull_request:
-    types: [opened, reopened, edited, synchronize, labeled]
+    types: [opened, reopened, edited, labeled, unlabeled, synchronize]
 
 jobs:
-  check:
+  check-changelog:
     runs-on: ubuntu-latest
     if: |
       !contains(github.event.pull_request.body, '[skip changelog]') &&
       !contains(github.event.pull_request.body, '[changelog skip]') &&
       !contains(github.event.pull_request.body, '[skip ci]') &&
-      !contains(github.event.pull_request.labels.*.name, 'skip changelog')
+      !contains(github.event.pull_request.labels.*.name, 'skip changelog') &&
+      !contains(github.event.pull_request.labels.*.name, 'dependencies')
     steps:
       - uses: actions/checkout@v3
       - name: Check that CHANGELOG is touched
-        run: git diff remotes/origin/${{ github.base_ref }} --name-only | grep CHANGELOG.md
+        run: |
+          git fetch origin ${{ github.base_ref }} --depth 1 && \
+          git diff remotes/origin/${{ github.base_ref }} --name-only | grep CHANGELOG.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## main
 
+* Only use `--retry-connrefused` on Ubuntu based stacks. 
+([#115](https://github.com/heroku/heroku-buildpack-gradle/pull/115))
+
 ## v38
 
 * Adjust curl retry and connection timeout handling

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -94,7 +94,15 @@ install_jdk() {
   let start=$(nowms)
   JVM_COMMON_BUILDPACK=${JVM_COMMON_BUILDPACK:-https://buildpack-registry.s3.us-east-1.amazonaws.com/buildpacks/heroku/jvm.tgz}
   mkdir -p /tmp/jvm-common
-  curl --fail --retry 3 --retry-connrefused --connect-timeout 5 --silent --location $JVM_COMMON_BUILDPACK | tar xzm -C /tmp/jvm-common --strip-components=1
+
+  # Some company-internal users are building their slugs on CentOS where these newer curl commands aren't
+  # supported yet. This conditional ensures their builds continue to work.
+  if curl --help all | grep -q -- --retry-connrefused; then
+    curl --fail --retry 3 --retry-connrefused --connect-timeout 5 --silent --location "${JVM_COMMON_BUILDPACK}" | tar xzm -C /tmp/jvm-common --strip-components=1
+  else
+    curl --fail --retry 3 --silent --location "${JVM_COMMON_BUILDPACK}" | tar xzm -C /tmp/jvm-common --strip-components=1
+  fi
+
   source /tmp/jvm-common/bin/util
   source /tmp/jvm-common/bin/java
   source /tmp/jvm-common/opt/jdbc.sh


### PR DESCRIPTION
Some internal users use this buildpack on nonstandard stacks where `--retry-connrefused` is not a supported curl flag. To unblock these users, the mentioned curl flag will now only be used on Ubuntu based stacks as a workaround.

Since there is currently only one `curl` execution in the whole buildpack, no helper function was added as a simple conditional is enough for this workaround.

Closes GUS-W-12168716