### PR TITLE
Provision heroku-postgresql if database driver is a dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## main
 
+## v40
+
+* Provision a Heroku Postgres addon when the app declares a dependency to the Postgres driver. This only affects new apps. This behaviour is now consistent with the `heroku/java` buildpack. ([#125](https://github.com/heroku/heroku-buildpack-gradle/pull/125))
+
 ## v39
 
 * Only use `--retry-connrefused` on Ubuntu based stacks. ([#115](https://github.com/heroku/heroku-buildpack-gradle/pull/115))

--- a/bin/release
+++ b/bin/release
@@ -26,6 +26,14 @@ _webapp_runner() {
 }
 
 echo "---"
+
+if has_postgres $BUILD_DIR; then
+  cat <<EOF
+addons:
+  - heroku-postgresql
+EOF
+fi
+
 if [ ! -f $BUILD_DIR/Procfile ]; then
   if is_spring_boot $BUILD_DIR; then
     echo "default_process_types:"

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -15,6 +15,12 @@ has_stage_task() {
      test -n "$(grep "^ *task *stage" ${gradleFile})"
 }
 
+has_postgres() {
+  local gradleFile="$(gradle_build_file ${1})"
+  test -f ${gradleFile} &&
+    test -n "$(grep "^[^/].*org.postgresql:postgresql" ${gradleFile})"
+}
+
 is_spring_boot() {
   local gradleFile="$(gradle_build_file ${1})"
    test -f ${gradleFile} &&


### PR DESCRIPTION
This mirrors the behaviour of `heroku/java`, making it possible to have a reasonable level of consistency for our getting started guide and the product itself. This change only affects new apps. Changelog updated for immediate release.

Closes GUS-W-12693964