### PR TITLE
Clean up CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,30 +1,30 @@
-# Gradle Buildpack Changelog
+# Changelog
 
-## main
+## [Unreleased]
 
 * Remove heroku-18 support ([#128](https://github.com/heroku/heroku-buildpack-gradle/pull/128))
 
-## v39
+## [v39] - 2022-12-06
 
 * Only use `--retry-connrefused` on Ubuntu based stacks. ([#115](https://github.com/heroku/heroku-buildpack-gradle/pull/115))
 * Allow usage of Kotlin DSL files (settings.gradle.kts, build.gradle.kts) ([#103](https://github.com/heroku/heroku-buildpack-gradle/pull/103))
 
-## v38
+## [v38] - 2022-06-14
 
 * Adjust curl retry and connection timeout handling
 * Vendor buildpack-stdlib rather than downloading it at build time
 * Switch to the recommended regional S3 domain instead of the global one
 
-## v37
+## [v37] - 2022-06-07
 
 * Add heroku-22 support
 
-## v36
+## [v36] - 2021-12-13
 
 * Fix a bug causing Gradle daemon to be unintentionally used when executing builds 
 * Remove heroku-16 support
 
-## v35
+## [v35] - 2021-02-23
 
 * Update tests
 
@@ -64,3 +64,10 @@
 ## v27
 
 * Add symlink from project .gradle to the cache
+
+[unreleased]: https://github.com/heroku/heroku-buildpack-gradle/compare/v39...HEAD
+[v39]: https://github.com/heroku/heroku-buildpack-gradle/compare/v38...v39
+[v38]: https://github.com/heroku/heroku-buildpack-gradle/compare/v37...v38
+[v37]: https://github.com/heroku/heroku-buildpack-gradle/compare/v36...v37
+[v36]: https://github.com/heroku/heroku-buildpack-gradle/compare/v35...v36
+[v35]: https://github.com/heroku/heroku-buildpack-gradle/compare/v34...v35


### PR DESCRIPTION
So that it uses a style slightly more consistent with https://keepachangelog.com, so that future automation can update it for new releases more easily.

GUS-W-14888899.