### PR TITLE
Add heroku-24 to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        stack: ["heroku-20", "heroku-22"]
+        stack: ["heroku-20", "heroku-22", "heroku-24"]
     env:
       HATCHET_APP_LIMIT: 100
       HATCHET_RUN_MULTI: 1

--- a/test/compile_test.sh
+++ b/test/compile_test.sh
@@ -8,8 +8,15 @@ installWrapper() {
   cp -r "$WRAPPER_DIR"/* ${BUILD_DIR}
 }
 
+requestOpenJdk8() {
+  cat > ${BUILD_DIR}/system.properties <<EOF
+java.runtime.version=8
+EOF
+}
+
 testCompileWithoutWrapper()
 {
+  requestOpenJdk8
   cat > ${BUILD_DIR}/build.gradle <<EOF
 task stage << {
   println "${expected_stage_output}"
@@ -23,6 +30,7 @@ EOF
 
 testCompileWithWrapper()
 {
+  requestOpenJdk8
   installWrapper
   expected_stage_output="STAGING:${RANDOM}"
 
@@ -34,7 +42,7 @@ EOF
 
   compile
   assertCapturedSuccess
-  assertCaptured "Installing OpenJDK 1.8"
+  assertCaptured "Installing OpenJDK 8"
   assertCaptured "${expected_stage_output}"
   assertCaptured "BUILD SUCCESSFUL"
   assertTrue "Java should be present in runtime." "[ -d ${BUILD_DIR}/.jdk ]"
@@ -46,6 +54,7 @@ EOF
 
 testCompileWithCustomTask()
 {
+  requestOpenJdk8
   installWrapper
   expected_stage_output="STAGING:${RANDOM}"
 
@@ -65,6 +74,7 @@ EOF
 
 testCompile_Fail()
 {
+  requestOpenJdk8
   installWrapper
   expected_stage_output="STAGING:${RANDOM}"
 

--- a/test/spec/fixtures/ci-test-app/system.properties
+++ b/test/spec/fixtures/ci-test-app/system.properties
@@ -1,0 +1,1 @@
+java.runtime.version=8


### PR DESCRIPTION
In addition to adding Heroku-24 to CI:

- Explicitly configure OpenJDK version in tests