### PR TITLE
Add Micronaut and Quarkus support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 * Remove heroku-18 support ([#128](https://github.com/heroku/heroku-buildpack-gradle/pull/128))
+* Add default process type and build task detection for Micronaut and Quarkus. ([#144](https://github.com/heroku/heroku-buildpack-gradle/pull/144))
 
 ## [v39] - 2022-12-06
 

--- a/bin/compile
+++ b/bin/compile
@@ -39,6 +39,12 @@ elif is_spring_boot $BUILD_DIR; then
     mcount "task.spring"
   fi
   DEFAULT_GRADLE_TASK="build -x ${GRADLE_CHECK_TASK}"
+elif is_micronaut $BUILD_DIR; then
+  echo "-----> Micronaut detected"
+  DEFAULT_GRADLE_TASK="shadowJar -x ${GRADLE_CHECK_TASK}"
+elif is_quarkus $BUILD_DIR; then
+  echo "-----> Quarkus detected"
+  DEFAULT_GRADLE_TASK="build -x ${GRADLE_CHECK_TASK}"
 elif is_ratpack $BUILD_DIR; then
   echo "-----> Ratpack detected"
   mcount "task.ratpack"

--- a/bin/release
+++ b/bin/release
@@ -37,6 +37,12 @@ if [ ! -f $BUILD_DIR/Procfile ]; then
   elif is_ratpack $BUILD_DIR && [ $(_ratpack_proc_count $BUILD_DIR) -eq 1 ]; then
     echo "default_process_types:"
     echo "  web: $(_ratpack_proc $BUILD_DIR)"
+  elif is_micronaut $BUILD_DIR; then
+    echo "default_process_types:"
+    echo "  web: java -Dmicronaut.server.port=\$PORT \$JAVA_OPTS -jar build/libs/*.jar"
+  elif is_quarkus $BUILD_DIR; then
+    echo "default_process_types:"
+    echo "  web: java -Dquarkus.http.port=\$PORT \$JAVA_OPTS -jar build/quarkus-app/quarkus-run.jar"
   else
     echo "{}"
   fi

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -26,6 +26,16 @@ is_spring_boot() {
      test -z "$(grep "org.grails:grails-" ${gradleFile})"
 }
 
+is_micronaut() {
+  local gradleFile="$(gradle_build_file ${1})"
+  test -f ${gradleFile} && test -n "$(grep "io.micronaut" ${gradleFile})"
+}
+
+is_quarkus() {
+  local gradleFile="$(gradle_build_file ${1})"
+  test -f ${gradleFile} && test -n "$(grep "io.quarkus" ${gradleFile})"
+}
+
 is_ratpack() {
   local gradleFile="$(gradle_build_file ${1})"
   test -f ${gradleFile} &&


### PR DESCRIPTION
QOL improvement for when users initially set up a Quarkus or Micronaut app. It picks the correct build task and sets a default web process type if no `Procfile` is present. This is the same mechanism we use for the other frameworks.