### PR TITLE
Add rollback to CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+## [v42] - 2025-06-16
+
+* This release is identical with `v40`, rolling back changes introduced in `v41`.
 
 ## [v41] - 2025-06-16
 


### PR DESCRIPTION
Release `v41` was rolled back in the registry. To keep version numbers in sync, this PR adds that version to the CHANGELOG.