### PR TITLE
Fix detection of the stage task when it has no description

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -199,7 +199,7 @@ echo "${detected_app_framework}" >"${BUILD_DIR}/.heroku/gradle_buildpack_detecte
 # Determine the Gradle task to execute
 if [ -z "${GRADLE_TASK:-}" ]; then
 	# If a stage task is available, use it instead of trying to guess the task to run
-	if (cd "${BUILD_DIR}" && ./gradlew tasks --all 2>/dev/null | grep -q "^stage "); then
+	if (cd "${BUILD_DIR}" && ./gradlew tasks --all 2>/dev/null | grep -q -E "^stage($|\s+.+)"); then
 		GRADLE_TASK="stage"
 	else
 		case "${detected_app_framework}" in


### PR DESCRIPTION
When listing all Gradle tasks, in the case when the stage task doesn't have a description, it will be listed alone on the line, without any space behind it