### PR TITLE
Improve test-compile resilience

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+- Improve test-compile resilience and performance. ([#175](https://github.com/heroku/heroku-buildpack-gradle/pull/175))
 
 ## [v46] - 2025-09-15
 

--- a/bin/compile
+++ b/bin/compile
@@ -294,23 +294,37 @@ if ! (cd "${BUILD_DIR}" && ./gradlew ${GRADLE_TASK}) 2>&1 | tee "${gradle_output
 	exit 1
 fi
 
-output::step "Stopping Gradle daemon"
-if [[ -f "${BUILD_DIR}/gradlew" ]]; then
-	(cd "${BUILD_DIR}" && ./gradlew -q --stop) | output::indent
-else
-	output::warning <<-EOF
-		Warning: Gradle wrapper (gradlew) not found during daemon cleanup.
+# We use an EXIT trap for cleanup to ensure it runs after all tasks are complete, even when sourced.
+# When bin/compile runs standalone, cleanup executes immediately since the script ends here.
+# When the script is sourced by bin/test-compile, cleanup is deferred until test-compile finishes.
 
-		The gradlew script was present at the beginning of the build but was removed
-		during the build process. This is unexpected behavior.
+exit_cleanup() {
+	# Only run cleanup when the script exits successfully (exit code 0).
+	# The $? variable contains the exit status of the script when the EXIT trap fires.
+	if [[ "${?}" -ne 0 ]]; then
+		return
+	fi
 
-		While this did not fail your current build, we strongly recommend fixing the
-		issue to prevent unexpected behavior in future builds. Check your Gradle tasks or
-		build scripts to see if they're removing the Gradle wrapper from your project directory.
-	EOF
+	if [[ -f "${BUILD_DIR}/gradlew" ]]; then
+		output::step "Stopping Gradle daemon"
+		(cd "${BUILD_DIR}" && ./gradlew -q --stop) | output::indent
+	else
+		output::warning <<-EOF
+			Warning: Gradle wrapper (gradlew) not found during daemon cleanup.
 
-	metrics::set_raw "gradle_daemon_cleanup_gradlew_missing" "true"
-fi
+			The gradlew script was present at the beginning of the build but was removed
+			during the build process. This is unexpected behavior.
 
-# https://github.com/heroku/heroku-buildpack-gradle/issues/49
-rm -rf "${CACHE_DIR}/.gradle/nodejs"
+			While this did not fail your current build, we strongly recommend fixing the
+			issue to prevent unexpected behavior in future builds. Check your Gradle tasks or
+			build scripts to see if they're removing the Gradle wrapper from your project directory.
+		EOF
+
+		metrics::set_raw "gradle_daemon_cleanup_gradlew_missing" "true"
+	fi
+
+	# https://github.com/heroku/heroku-buildpack-gradle/issues/49
+	rm -rf "${CACHE_DIR}/.gradle/nodejs"
+}
+
+trap exit_cleanup EXIT

--- a/bin/test-compile
+++ b/bin/test-compile
@@ -40,7 +40,7 @@ output::step "Resolving test runtime dependencies"
 (cd "${BUILD_DIR}" && ./gradlew --init-script "${heroku_gradle_init_script}" resolveTestRuntime) 2>&1 | output::indent
 
 # Copy the contents of the Gradle user home to the build directory so that configuration
-# and build caches are available as runtime for tests.
+# and build caches are available at runtime for tests.
 util::cache_copy ".gradle" "${CACHE_DIR}" "${BUILD_DIR}"
 
 mkdir -p "${BUILD_DIR}/.profile.d"

--- a/bin/test-compile
+++ b/bin/test-compile
@@ -8,10 +8,6 @@ export GRADLE_TASK="testClasses"
 
 source "${BUILDPACK_DIR}/bin/compile"
 
-# Copy the contents of the Gradle user home to the build directory so that configuration
-# and build caches are available as runtime for tests.
-util::cache_copy ".gradle" "${CACHE_DIR}" "${BUILD_DIR}"
-
 # We need to resolve the test runtime dependencies for the tests to run, but Gradle doesn't have a built-in way to do this.
 # Instead, we use a custom init script to resolve the dependencies.
 # https://docs.gradle.org/current/userguide/init_scripts.html
@@ -43,8 +39,9 @@ EOF
 output::step "Resolving test runtime dependencies"
 (cd "${BUILD_DIR}" && ./gradlew --init-script "${heroku_gradle_init_script}" resolveTestRuntime) 2>&1 | output::indent
 
-# Write the Gradle user home back into the cache to make sure the test dependencies get permanently cached too.
-util::cache_copy ".gradle" "${BUILD_DIR}" "${CACHE_DIR}"
+# Copy the contents of the Gradle user home to the build directory so that configuration
+# and build caches are available as runtime for tests.
+util::cache_copy ".gradle" "${CACHE_DIR}" "${BUILD_DIR}"
 
 mkdir -p "${BUILD_DIR}/.profile.d"
 cat <<-EOF >"${BUILD_DIR}/.profile.d/gradle.sh"

--- a/test/spec/ci_spec.rb
+++ b/test/spec/ci_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe 'Gradle buildpack' do
                
                BUILD SUCCESSFUL in \\d+s
                3 actionable tasks: 3 executed
-        -----> Stopping Gradle daemon
+        -----> REDACTED
         -----> Resolving test runtime dependencies
                Starting a Gradle Daemon, \\d+ stopped Daemon could not be reused, use --status for details
                > Task :resolveTestRuntime
@@ -66,7 +66,7 @@ RSpec.describe 'Gradle buildpack' do
                
                BUILD SUCCESSFUL in \\d+s
                3 actionable tasks: 1 executed, 2 from cache
-        -----> Stopping Gradle daemon
+        -----> REDACTED
         -----> Resolving test runtime dependencies
                Starting a Gradle Daemon, \\d+ stopped Daemon could not be reused, use --status for details
                > Task :resolveTestRuntime

--- a/test/spec/ci_spec.rb
+++ b/test/spec/ci_spec.rb
@@ -20,13 +20,12 @@ RSpec.describe 'Gradle buildpack' do
                
                BUILD SUCCESSFUL in \\d+s
                3 actionable tasks: 3 executed
-        -----> REDACTED
         -----> Resolving test runtime dependencies
-               Starting a Gradle Daemon, \\d+ stopped Daemon could not be reused, use --status for details
                > Task :resolveTestRuntime
                
                BUILD SUCCESSFUL in \\d+s
                1 actionable task: 1 executed
+        -----> Stopping Gradle daemon
         -----> No test-setup command provided\\. Skipping\\.
         -----> Running Gradle buildpack tests...
         Picked up JAVA_TOOL_OPTIONS: -Dfile\\.encoding=UTF-8 -XX:MaxRAM=2684354560 -XX:MaxRAMPercentage=80\\.0
@@ -66,13 +65,12 @@ RSpec.describe 'Gradle buildpack' do
                
                BUILD SUCCESSFUL in \\d+s
                3 actionable tasks: 1 executed, 2 from cache
-        -----> REDACTED
         -----> Resolving test runtime dependencies
-               Starting a Gradle Daemon, \\d+ stopped Daemon could not be reused, use --status for details
                > Task :resolveTestRuntime
                
                BUILD SUCCESSFUL in \\d+s
                1 actionable task: 1 executed
+        -----> Stopping Gradle daemon
         -----> No test-setup command provided\\. Skipping\\.
         -----> Running Gradle buildpack tests...
         Picked up JAVA_TOOL_OPTIONS: -Dfile\\.encoding=UTF-8 -XX:MaxRAM=2684354560 -XX:MaxRAMPercentage=80\\.0


### PR DESCRIPTION
## Summary

- Use EXIT trap for daemon cleanup to ensure it runs after all tasks complete, even when sourced
- Tasks in bin/test-compile can now use the daemon for improved speed
- Only copy GRADLE_USER_HOME to BUILD_DIR for runtime use by bin/test without copying back to cache, in some cases the second copy failed for customers. Since it's now unnecessary that issue should be resolved.

GUS-W-19647427