### PR TITLE
Fix stage task detection to work regardless of description presence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix `stage` task detection to work regardless of whether task has a description. ([#177](https://github.com/heroku/heroku-buildpack-gradle/pull/177))
 
 ## [v47] - 2025-09-16
 

--- a/bin/compile
+++ b/bin/compile
@@ -199,7 +199,7 @@ echo "${detected_app_framework}" >"${BUILD_DIR}/.heroku/gradle_buildpack_detecte
 # Determine the Gradle task to execute
 if [ -z "${GRADLE_TASK:-}" ]; then
 	# If a stage task is available, use it instead of trying to guess the task to run
-	if (cd "${BUILD_DIR}" && ./gradlew tasks --all 2>/dev/null | grep -q "^stage "); then
+	if (cd "${BUILD_DIR}" && ./gradlew tasks --all 2>/dev/null | grep -qE "^stage($| )"); then
 		GRADLE_TASK="stage"
 	else
 		case "${detected_app_framework}" in

--- a/test/spec/misc_spec.rb
+++ b/test/spec/misc_spec.rb
@@ -196,4 +196,41 @@ RSpec.describe 'Gradle buildpack' do
       )
     end
   end
+
+  it 'uses stage task (with description) when available' do
+    app = Hatchet::Runner.new('spring-3-gradle-8-groovy')
+    app.before_deploy do
+      stage_task = <<~GROOVY
+        task stage {
+            description = 'Custom stage task for deployment'
+            dependsOn build
+        }
+      GROOVY
+
+      File.write('build.gradle', "#{File.read('build.gradle')}\n#{stage_task}")
+    end
+
+    app.deploy do
+      expect(app).to be_deployed
+      expect(clean_output(app.output)).to include('$ ./gradlew stage')
+    end
+  end
+
+  it 'uses stage task (without description) when available' do
+    app = Hatchet::Runner.new('spring-3-gradle-8-groovy')
+    app.before_deploy do
+      stage_task = <<~GROOVY
+        task stage {
+            dependsOn build
+        }
+      GROOVY
+
+      File.write('build.gradle', "#{File.read('build.gradle')}\n#{stage_task}")
+    end
+
+    app.deploy do
+      expect(app).to be_deployed
+      expect(clean_output(app.output)).to include('$ ./gradlew stage')
+    end
+  end
 end


### PR DESCRIPTION
## Summary

- Fix stage task detection regex to match tasks with or without descriptions.
- Add regression tests to prevent future issues.
- Reported via #174 (thanks @stanfds!), but fix broke existing apps, didn't have tests.

## Context

The current stage task detection uses `grep -q "^stage "` which requires a space after "stage". This fails to detect stage tasks that don't have descriptions, as they appear as just `stage` without trailing spaces in `gradle tasks --all` output.

## Changes

- Update regex from `^stage ` to `^stage($| )` to match both scenarios.
- Add regression tests using existing fixtures, failing run before the actual fix can be seen here: https://github.com/heroku/heroku-buildpack-gradle/actions/runs/17771603414/job/50564830429