### PR TITLE
Configure classic publish notifications

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,3 +29,7 @@ jobs:
     uses: heroku/languages-github-actions/.github/workflows/_classic-buildpack-publish.yml@latest
     with:
       buildpack_id: "heroku/gradle"
+      app_id: ${{ vars.LINGUIST_GH_APP_ID }}
+    secrets:
+      app_private_key: ${{ secrets.LINGUIST_GH_PRIVATE_KEY }}
+      slack_webhook_url: ${{ secrets.BUILDPACK_RELEASE_FAILURE_WEBHOOK_URL }}


### PR DESCRIPTION
## Summary

Configures the classic Gradle buildpack into the publish notifications added to the shared `_classic-buildpack-publish.yml` workflow (heroku/languages-github-actions#370, already merged):

- Passes the **Linguist GitHub App** (`app_id` + `app_private_key`) so the workflow's `notify-start` / `notify-failure` jobs can comment on the triggering "Prepare release" PR and author the GitHub Release as the App — matching the CNB release automation.
- Passes the `BUILDPACK_RELEASE_FAILURE_WEBHOOK_URL` repo secret as the workflow's `slack_webhook_url` input, so production publish failures post to `#heroku-languages-ops`.

The reusable workflow now declares `app_id` (input) plus `app_private_key` / `slack_webhook_url` (secrets) as **required**, so a caller that doesn't pass them errors at the `workflow_call`. This PR supplies all three.

## Prerequisites

- `vars.LINGUIST_GH_APP_ID` and `secrets.LINGUIST_GH_PRIVATE_KEY` — org-level, already used by `prepare_release.yml`.
- `BUILDPACK_RELEASE_FAILURE_WEBHOOK_URL` repo secret (Slack Workflow Builder webhook for `#heroku-languages-ops`) — **must be set on this repo before the next release** (will be provisioned manually).

W-22900983